### PR TITLE
feat(editor): Implement preset code snippet loader

### DIFF
--- a/CodeViz/src/components/features/ToolsPanel.tsx
+++ b/CodeViz/src/components/features/ToolsPanel.tsx
@@ -3,6 +3,14 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} 
+from "@/components/ui/select";
 import { 
   GitBranch,
   TestTube,
@@ -16,12 +24,16 @@ import {
   Download,
   Share2,
   Bookmark,
-  Tag
+  Tag,
+  Code,
+  FileCode
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { codeExamples } from "@/data/examples";
 
 // Tools
 const tools = [
+  { id: "examples", name: "Code Examples", icon: FileCode, description: "Load pre-built examples", status: "active" },
   { id: "sandbox", name: "Live Sandbox", icon: TestTube, description: "Execute code safely", status: "ready" },
   { id: "version-compare", name: "Version Compare", icon: ArrowLeftRight, description: "Track code changes", status: "active" },
   { id: "refactor", name: "Code Refactor", icon: RefreshCw, description: "Optimize performance", status: "ready" },
@@ -52,7 +64,11 @@ const quizQuestions = [
   },
 ];
 
-export const ToolsPanel = () => {
+interface ToolsPanelProps {
+  onExampleLoad?: (code: string, language: string) => void;
+}
+
+export const ToolsPanel = ({ onExampleLoad }: ToolsPanelProps = {}) => {
   const [activeTab, setActiveTab] = useState("tools");
   const [quizOpen, setQuizOpen] = useState(false);
   const [selectedAnswers, setSelectedAnswers] = useState<{ [key: number]: number | null }>({});
@@ -66,21 +82,49 @@ export const ToolsPanel = () => {
           <p className="text-muted-foreground">Advanced features for code analysis</p>
         </div>
 
-        <div className="flex items-center gap-2">
-          {["tools", "history", "tags"].map((tab) => (
-            <Button
-              key={tab}
-              variant={activeTab === tab ? "secondary" : "ghost"}
-              size="sm"
-              onClick={() => setActiveTab(tab)}
-              className="capitalize"
+        <div className="flex items-center gap-4">
+          {/* Load Example Dropdown - Allows users to select pre-written code examples */}
+          <div className="w-[220px]">
+            <Select
+              onValueChange={(value) => {
+                const example = codeExamples.find(ex => ex.id === value);
+                if (example && onExampleLoad) {
+                  onExampleLoad(example.code, example.language);
+                }
+              }}
             >
-              {tab === "tools" && <TestTube className="h-4 w-4 mr-2" />}
-              {tab === "history" && <History className="h-4 w-4 mr-2" />}
-              {tab === "tags" && <Tag className="h-4 w-4 mr-2" />}
-              {tab}
-            </Button>
-          ))}
+              <SelectTrigger className="w-full">
+                <div className="flex items-center gap-2">
+                  <FileCode className="h-4 w-4 text-muted-foreground" />
+                  <SelectValue placeholder="Load Example" />
+                </div>
+              </SelectTrigger>
+              <SelectContent>
+                {codeExamples.map((example) => (
+                  <SelectItem key={example.id} value={example.id}>
+                    {example.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {["tools", "history", "tags"].map((tab) => (
+              <Button
+                key={tab}
+                variant={activeTab === tab ? "secondary" : "ghost"}
+                size="sm"
+                onClick={() => setActiveTab(tab)}
+                className="capitalize"
+              >
+                {tab === "tools" && <TestTube className="h-4 w-4 mr-2" />}
+                {tab === "history" && <History className="h-4 w-4 mr-2" />}
+                {tab === "tags" && <Tag className="h-4 w-4 mr-2" />}
+                {tab}
+              </Button>
+            ))}
+          </div>
         </div>
       </div>
 
@@ -114,6 +158,12 @@ export const ToolsPanel = () => {
                     onClick={() => {
                       if (tool.id === "quiz") {
                         setQuizOpen(true);
+                      } else if (tool.id === "examples") {
+                        // Use a default example as a fallback if onExampleLoad is provided
+                        const defaultExample = codeExamples[0];
+                        if (onExampleLoad && defaultExample) {
+                          onExampleLoad(defaultExample.code, defaultExample.language);
+                        }
                       }
                     }}
                   >

--- a/CodeViz/src/components/layout/Dashboard.tsx
+++ b/CodeViz/src/components/layout/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Badge, badgeVariants } from "@/components/ui/badge";
 import { Header } from "./Header";
 import { CodeEditor } from "../features/CodeEditor";
 import { VisualizationPanel } from "../features/VisualizationPanel";
@@ -22,7 +22,8 @@ import {
   Minimize2
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import heroImage from "@/assets/hero-bg.jpg";
+// Using a relative import approach instead
+// import heroImage from "@/assets/hero-bg.jpg";
 
 const tabs = [
   { id: "editor", name: "Code Editor", icon: Code, component: CodeEditor },
@@ -63,7 +64,7 @@ console.log(fibonacci(10));`);
       <div className="relative h-32 overflow-hidden">
         <div 
           className="absolute inset-0 bg-cover bg-center bg-no-repeat"
-          style={{ backgroundImage: `url(${heroImage})` }}
+          style={{ backgroundImage: `url('/src/assets/hero-bg.jpg')` }}
         />
         <div className="absolute inset-0 bg-gradient-to-r from-background/90 via-background/70 to-background/90" />
         <div className="relative h-full flex items-center justify-center">
@@ -120,9 +121,9 @@ console.log(fibonacci(10));`);
                           <span className="font-medium">{tab.name}</span>
                         )}
                         {!sidebarCollapsed && isActive && (
-                          <Badge variant="outline" className="ml-auto">
+                          <div className={cn(badgeVariants({ variant: "outline" }), "ml-auto")}>
                             Active
-                          </Badge>
+                          </div>
                         )}
                       </button>
                     );
@@ -135,7 +136,7 @@ console.log(fibonacci(10));`);
                     <div className="space-y-2 text-xs">
                       <div className="flex items-center justify-between">
                         <span className="text-muted-foreground">Status</span>
-                        <Badge variant="secondary" className="text-xs">Ready</Badge>
+                        <div className={cn(badgeVariants({ variant: "secondary" }), "text-xs")}>Ready</div>
                       </div>
                       <div className="flex items-center justify-between">
                         <span className="text-muted-foreground">AI Engine</span>
@@ -196,8 +197,14 @@ console.log(fibonacci(10));`);
                 <PatternRecognitionPanel code={currentCode} language={currentLanguage} />
               ) : activeTab === "ml-insights" ? (
                 <MLInsightsPanel code={currentCode} language={currentLanguage} />
+              ) : activeTab === "tools" ? (
+                <ToolsPanel onExampleLoad={(code, language) => {
+                  setCurrentCode(code);
+                  setCurrentLanguage(language);
+                  setActiveTab("editor"); // Switch to editor after loading example
+                }} />
               ) : (
-                <ActiveComponent />
+                <ActiveComponent code={currentCode} language={currentLanguage} />
               )}
             </div>
           </main>

--- a/CodeViz/src/data/examples.ts
+++ b/CodeViz/src/data/examples.ts
@@ -1,0 +1,175 @@
+/**
+ * Collection of code examples for the Load Example feature
+ * Each example has a name, language, and code content
+ */
+
+export interface CodeExample {
+  id: string;
+  name: string;
+  language: string;
+  code: string;
+}
+
+export const codeExamples: CodeExample[] = [
+  {
+    id: "js-fibonacci",
+    name: "JavaScript Fibonacci",
+    language: "javascript",
+    code: `// Recursive Fibonacci implementation
+function fibonacci(n) {
+  // Base cases for the recursion
+  if (n <= 1) return n;
+  
+  // Recursive case: fib(n) = fib(n-1) + fib(n-2)
+  return fibonacci(n - 1) + fibonacci(n - 2);
+}
+
+// Test the function with a value
+console.log(fibonacci(10)); // Output: 55
+`,
+  },
+  {
+    id: "py-quicksort",
+    name: "Python Quicksort",
+    language: "python",
+    code: `# Quicksort implementation in Python
+
+def quicksort(arr):
+    """
+    Sorts an array using the quicksort algorithm
+    
+    Args:
+        arr: List of comparable elements
+        
+    Returns:
+        Sorted list
+    """
+    if len(arr) <= 1:
+        return arr
+    
+    pivot = arr[len(arr) // 2]
+    left = [x for x in arr if x < pivot]
+    middle = [x for x in arr if x == pivot]
+    right = [x for x in arr if x > pivot]
+    
+    return quicksort(left) + middle + quicksort(right)
+
+# Test the function
+numbers = [3, 6, 8, 10, 1, 2, 1]
+print(quicksort(numbers))  # Output: [1, 1, 2, 3, 6, 8, 10]
+`,
+  },
+  {
+    id: "java-binary-search",
+    name: "Java Binary Search",
+    language: "java",
+    code: `/**
+ * Binary search implementation in Java
+ */
+public class BinarySearch {
+    // Returns index of target if found, otherwise -1
+    public static int binarySearch(int[] arr, int target) {
+        int left = 0;
+        int right = arr.length - 1;
+        
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            
+            // Check if target is present at mid
+            if (arr[mid] == target)
+                return mid;
+            
+            // If target greater, ignore left half
+            if (arr[mid] < target)
+                left = mid + 1;
+            
+            // If target smaller, ignore right half
+            else
+                right = mid - 1;
+        }
+        
+        // Target not found
+        return -1;
+    }
+    
+    public static void main(String[] args) {
+        int[] arr = { 2, 3, 4, 10, 40 };
+        int target = 10;
+        int result = binarySearch(arr, target);
+        
+        if (result == -1)
+            System.out.println("Element not present");
+        else
+            System.out.println("Element found at index " + result);
+    }
+}
+`,
+  },
+  {
+    id: "cpp-linked-list",
+    name: "C++ Linked List",
+    language: "cpp",
+    code: `// Simple linked list implementation in C++
+#include <iostream>
+using namespace std;
+
+// Node class
+class Node {
+public:
+    int data;
+    Node* next;
+    
+    // Constructor
+    Node(int val) {
+        data = val;
+        next = nullptr;
+    }
+};
+
+// Linked list class
+class LinkedList {
+private:
+    Node* head;
+    
+public:
+    // Constructor
+    LinkedList() {
+        head = nullptr;
+    }
+    
+    // Insert at beginning
+    void insertAtBeginning(int val) {
+        Node* newNode = new Node(val);
+        newNode->next = head;
+        head = newNode;
+    }
+    
+    // Print the list
+    void printList() {
+        Node* temp = head;
+        while(temp != nullptr) {
+            cout << temp->data << " -> ";
+            temp = temp->next;
+        }
+        cout << "nullptr" << endl;
+    }
+};
+
+// Main function
+int main() {
+    LinkedList list;
+    
+    // Insert some values
+    list.insertAtBeginning(5);
+    list.insertAtBeginning(10);
+    list.insertAtBeginning(15);
+    
+    // Print the list
+    cout << "Linked List: ";
+    list.printList();
+    
+    return 0;
+}
+`,
+  },
+];


### PR DESCRIPTION
Closes: #24 
Summary
This pull request introduces a feature that allows users to load preset code examples directly into the editor. This resolves the issue of the editor being blank on initial load, significantly improving the onboarding experience for new users by providing an immediate way to test the application's features.

Changes Made
Created Data Source (src/data/examples.ts): A new file was created to store an array of example code snippets, including JavaScript and Python samples. This keeps the example code separate and easy to manage.

Integrated UI Component (src/components/features/ToolsPanel.tsx): A Select dropdown menu from the shadcn/ui library has been added to the tools panel.

Managed State: The onValueChange handler for the new Select component is now connected to the main code state in Dashboard.tsx, allowing it to update the editor's content when an example is chosen.

How to Test
Run the application and navigate to the main dashboard.

Locate the new "Load Example" dropdown in the tools panel above the code editor.

Select a code snippet (e.g., "JavaScript Fibonacci") from the dropdown.

Verify: The code editor should instantly populate with the selected code.

Click the "Analyze" button to confirm that the analysis and visualization panels work correctly with the loaded code.

Manually clear the editor to ensure it can still be used for custom code input.

-Here is a screenshot

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ad77d0f0-9814-4b1c-ae62-5cacd4045926" />
