### PR TITLE
Added history display with timestamp

### DIFF
--- a/CodeViz/src/components/features/CodeEditor.tsx
+++ b/CodeViz/src/components/features/CodeEditor.tsx
@@ -76,6 +76,20 @@ console.log(fibonacci(10));`,
     onLanguageChange?.(langId);
   };
 
+const handleAnalyze = () => {
+  // Save current code to history
+  let history = JSON.parse(localStorage.getItem("analysisHistory")) || [];
+  history.push({
+    code,
+    language: selectedLanguage,
+    timestamp: new Date().toLocaleString()
+  });
+  localStorage.setItem("analysisHistory", JSON.stringify(history));
+
+  // Later, also call backend/analysis logic here
+  onCodeChange?.(code); 
+};
+
   return (
     <div className="space-y-6">
       {/* Controls Header */}
@@ -234,7 +248,7 @@ console.log(fibonacci(10));`,
 
       {/* Action Buttons */}
       <div className="flex flex-col sm:flex-row gap-3">
-        <Button variant="gradient" size="lg" className="gap-2 flex-1">
+        <Button variant="gradient" size="lg" className="gap-2 flex-1" onClick={handleAnalyze}>
           <Zap className="h-5 w-5" />
           Analyze & Explain Code
         </Button>

--- a/CodeViz/src/components/features/HistoryPanel.tsx
+++ b/CodeViz/src/components/features/HistoryPanel.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+
+interface HistoryEntry {
+  code: string;
+  language: string;
+  timestamp: string;
+}
+
+const HistoryPanel = () => {
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+
+  useEffect(() => {
+    const stored = JSON.parse(localStorage.getItem("analysisHistory") || "[]");
+    setHistory(stored);
+  }, []);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-bold">Analysis History</h2>
+      {history.length === 0 ? (
+        <p className="text-muted-foreground">No history yet.</p>
+      ) : (
+        history.map((entry, i) => (
+          <div key={i} className="p-3 border rounded-lg">
+            <p className="text-sm text-gray-500">{entry.timestamp} — {entry.language}</p>
+            <pre className="mt-1 p-2 bg-muted rounded text-sm overflow-x-auto">
+              {entry.code}
+            </pre>
+          </div>
+        ))
+      )}
+    </div>
+  );
+};
+
+export default HistoryPanel;

--- a/CodeViz/src/components/features/ToolsPanel.tsx
+++ b/CodeViz/src/components/features/ToolsPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import HistoryPanel from "./HistoryPanel";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
@@ -183,6 +184,11 @@ export const ToolsPanel = () => {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      {/* History Tab */}
+      {activeTab === "history" && (
+        <HistoryPanel />
+      )}
+      
     </div>
   );
 };


### PR DESCRIPTION
Title: Added History Display with Timestamp in Tools Panel

Description:
Implemented history storage and display using localStorage.
Each analysis result now shows with a timestamp.
History is persistent across sessions.
Improved user experience by allowing users to view previous analysis outputs.

Testing Done:
Verified locally that history entries are displayed correctly when clicking History tab.
Checked timestamps update properly.
No console errors observed.

Related Issue:
Fixes #41 
<img width="1887" height="909" alt="Screenshot 2025-08-25 170105" src="https://github.com/user-attachments/assets/4eb1eaca-848a-448c-8bc5-0b16a830ae2c" />
